### PR TITLE
1--return factored matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ result_data = decompose(
     kernel_strategy=KernelStrategy.GAUSSIAN_MODEL_SINGLE_VARIANCE,
     verbose=True
 )
-model_means_L = result_data.reconstruction
+model_means_L = result_data.factors[0] @ result_data.factors[1]
 model_variance = result_data.variance
 
 # use model_means_L as appropriate for your application

--- a/src/fi_nomad/kernels/base_model_free.py
+++ b/src/fi_nomad/kernels/base_model_free.py
@@ -78,9 +78,7 @@ class BaseModelFree(KernelBase):
         """
         floss = str(self.loss) if self.loss != float("inf") else "Not Tracked"
         text = f"{self.elapsed_iterations} total, final loss {floss}"
-        data = BaseModelFreeKernelReturnType(
-            self.low_rank_candidate_L, two_part_factor(self.low_rank_candidate_L)
-        )
+        data = BaseModelFreeKernelReturnType(two_part_factor(self.low_rank_candidate_L))
         return KernelReturnType(text, data)
 
 

--- a/src/fi_nomad/kernels/base_model_free.py
+++ b/src/fi_nomad/kernels/base_model_free.py
@@ -12,10 +12,7 @@ from fi_nomad.types import (
     KernelReturnType,
     LossType,
 )
-from fi_nomad.util import (
-    find_low_rank,
-    compute_loss,
-)
+from fi_nomad.util import find_low_rank, compute_loss, two_part_factor
 
 
 class BaseModelFree(KernelBase):
@@ -81,7 +78,9 @@ class BaseModelFree(KernelBase):
         """
         floss = str(self.loss) if self.loss != float("inf") else "Not Tracked"
         text = f"{self.elapsed_iterations} total, final loss {floss}"
-        data = BaseModelFreeKernelReturnType(self.low_rank_candidate_L)
+        data = BaseModelFreeKernelReturnType(
+            self.low_rank_candidate_L, two_part_factor(self.low_rank_candidate_L)
+        )
         return KernelReturnType(text, data)
 
 

--- a/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
@@ -16,10 +16,7 @@ from fi_nomad.types import (
     KernelReturnType,
     LossType,
 )
-from fi_nomad.util import (
-    compute_loss,
-    find_low_rank,
-)
+from fi_nomad.util import compute_loss, find_low_rank, two_part_factor
 from fi_nomad.util.gauss_model_util import (
     get_stddev_normalized_matrix_gamma,
     get_posterior_means_Z,
@@ -203,6 +200,7 @@ class RowwiseVarianceGaussianModelKernel(KernelBase):
         )
         data = RowwiseVarianceGaussianModelKernelReturnType(
             self.model_means_L,
+            two_part_factor(self.model_means_L),
             self.model_variance_sigma_squared,
         )
         return KernelReturnType(text, data)

--- a/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
@@ -199,7 +199,6 @@ class RowwiseVarianceGaussianModelKernel(KernelBase):
             + f"likelihood {self.likelihood}"
         )
         data = RowwiseVarianceGaussianModelKernelReturnType(
-            self.model_means_L,
             two_part_factor(self.model_means_L),
             self.model_variance_sigma_squared,
         )

--- a/src/fi_nomad/kernels/single_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/single_variance_gauss_model.py
@@ -125,7 +125,6 @@ class SingleVarianceGaussianModelKernel(KernelBase):
             + f"{self.loss} likelihood {self.likelihood}"
         )
         data = SingleVarianceGaussianModelKernelReturnType(
-            self.model_means_L,
             two_part_factor(self.model_means_L),
             self.model_variance_sigma_squared,
         )

--- a/src/fi_nomad/kernels/single_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/single_variance_gauss_model.py
@@ -16,10 +16,7 @@ from fi_nomad.types import (
     LossType,
     SingleVarianceGaussianModelKernelReturnType,
 )
-from fi_nomad.util import (
-    compute_loss,
-    find_low_rank,
-)
+from fi_nomad.util import compute_loss, find_low_rank, two_part_factor
 from fi_nomad.util.gauss_model_util import (
     get_stddev_normalized_matrix_gamma,
     get_posterior_means_Z,
@@ -129,6 +126,7 @@ class SingleVarianceGaussianModelKernel(KernelBase):
         )
         data = SingleVarianceGaussianModelKernelReturnType(
             self.model_means_L,
+            two_part_factor(self.model_means_L),
             self.model_variance_sigma_squared,
         )
         return KernelReturnType(text, data)

--- a/src/fi_nomad/types/kernelReturnTypes.py
+++ b/src/fi_nomad/types/kernelReturnTypes.py
@@ -13,20 +13,16 @@ from typing import Tuple, Union
 from dataclasses import dataclass
 from .types import FloatArrayType
 
-# This will facilitate a future conversion from returning the full
-# low-rank matrix to returning a factored version.
-SolutionType_Unfactored = FloatArrayType
 SolutionType = Tuple[FloatArrayType, FloatArrayType]
 
 
 @dataclass
 class KernelReturnBase(ABC):
     """Base interface for returned kernel data. Enforces that every kernel
-    must return consistent members with the reconstructed solution.
+    must return consistent member(s) containing the reconstructed solution.
     """
 
-    reconstruction: SolutionType_Unfactored
-    factored_solution: SolutionType
+    factors: SolutionType
 
 
 @dataclass

--- a/src/fi_nomad/types/kernelReturnTypes.py
+++ b/src/fi_nomad/types/kernelReturnTypes.py
@@ -9,24 +9,24 @@ Classes:
 
 """
 from abc import ABC
-from typing import Union
+from typing import Tuple, Union
 from dataclasses import dataclass
 from .types import FloatArrayType
 
 # This will facilitate a future conversion from returning the full
 # low-rank matrix to returning a factored version.
-SolutionType = FloatArrayType
+SolutionType_Unfactored = FloatArrayType
+SolutionType = Tuple[FloatArrayType, FloatArrayType]
 
 
 @dataclass
 class KernelReturnBase(ABC):
     """Base interface for returned kernel data. Enforces that every kernel
-    must return a "reconstruction" member with its solution.
-    This facilitates usability and a smoother transition to returning the
-    decomposed version of the low-rank estimation matrix.
+    must return consistent members with the reconstructed solution.
     """
 
-    reconstruction: SolutionType
+    reconstruction: SolutionType_Unfactored
+    factored_solution: SolutionType
 
 
 @dataclass

--- a/src/fi_nomad/util/__init__.py
+++ b/src/fi_nomad/util/__init__.py
@@ -1,4 +1,7 @@
-from .decomposition_util import find_low_rank as find_low_rank
+from .decomposition_util import (
+    find_low_rank as find_low_rank,
+    two_part_factor as two_part_factor,
+)
 from .initialization_util import (
     initialize_low_rank_candidate as initialize_low_rank_candidate,
 )

--- a/src/fi_nomad/util/decomposition_util.py
+++ b/src/fi_nomad/util/decomposition_util.py
@@ -2,8 +2,10 @@
 
 Functions:
     find_low_rank: Compute low-rank approximation to input matrix using stated SVD strategy.
+    two_part_factor: Factor M x N matrix of rank r into A (M x r), B (r x N)
 
 """
+from typing import Tuple
 import numpy as np
 from sklearn.decomposition import TruncatedSVD  # type: ignore
 
@@ -118,3 +120,21 @@ def find_low_rank(
     if strategy == SVDStrategy.FULL:
         return _find_low_rank_full(utility_matrix, target_rank, low_rank)
     raise ValueError("Unsupported SVD strategy.")
+
+
+def two_part_factor(matrix: FloatArrayType) -> Tuple[FloatArrayType, FloatArrayType]:
+    """Factor matrix into two rectangular matrices with inner dimension matching its rank.
+
+    Args:
+        matrix: Low-rank matrix to factor into two
+
+    Returns:
+        Two matrices whose product is the original matrix.
+    """
+    rank = np.linalg.matrix_rank(matrix)
+    (svd_U, svd_S, svd_Vt) = np.linalg.svd(matrix)
+    inner_a = np.zeros((matrix.shape[0], rank))
+    np.fill_diagonal(inner_a, svd_S)
+    part_A = svd_U @ inner_a
+    part_B = np.pad(np.eye(rank), ((0, 0), (0, matrix.shape[1] - rank))) @ svd_Vt
+    return (part_A, part_B)

--- a/test/integration_tests/integration_test.py
+++ b/test/integration_tests/integration_test.py
@@ -57,23 +57,22 @@ def test_random_matrix_recovery(kernel: KernelStrategy) -> None:
         kernel,
         tolerance=random_matrix_tolerance,
     )
-    low_rank = result.reconstruction
+    low_rank = result.factors[0] @ result.factors[1]
     low_rank_relu = np.copy(low_rank)
     low_rank_relu[low_rank_relu < 0] = 0
     sparse_loss = compute_loss(low_rank_relu, random_matrix_sparse)
     assert sparse_loss < random_matrix_tolerance
-    lowrank_factored = result.factored_solution[0] @ result.factored_solution[1]
+    lowrank_factored = result.factors[0] @ result.factors[1]
     np.testing.assert_allclose(lowrank_factored, low_rank)
 
 
 @pytest.mark.parametrize("kernel", all_kernels)
 def test_model_kernel_elevens_matrix_recovery(kernel: KernelStrategy) -> None:
     result = decompose(eleven_matrix, eleven_matrix_target_rank, kernel)
-    relu_l = np.copy(result.reconstruction)
+    low_rank = result.factors[0] @ result.factors[1]
+    relu_l = np.copy(low_rank)
     relu_l[relu_l < 0] = 0
     if kernel == KernelStrategy.BASE_MODEL_FREE:
         assert np.allclose(relu_l, eleven_matrix, atol=BASE_MODEL_FREE_ELEVENS_ATOL)
     else:
         assert np.allclose(relu_l, eleven_matrix)
-    lowrank_factored = result.factored_solution[0] @ result.factored_solution[1]
-    np.testing.assert_allclose(lowrank_factored, result.reconstruction)

--- a/test/integration_tests/integration_test.py
+++ b/test/integration_tests/integration_test.py
@@ -62,6 +62,8 @@ def test_random_matrix_recovery(kernel: KernelStrategy) -> None:
     low_rank_relu[low_rank_relu < 0] = 0
     sparse_loss = compute_loss(low_rank_relu, random_matrix_sparse)
     assert sparse_loss < random_matrix_tolerance
+    lowrank_factored = result.factored_solution[0] @ result.factored_solution[1]
+    np.testing.assert_allclose(lowrank_factored, low_rank)
 
 
 @pytest.mark.parametrize("kernel", all_kernels)
@@ -73,3 +75,5 @@ def test_model_kernel_elevens_matrix_recovery(kernel: KernelStrategy) -> None:
         assert np.allclose(relu_l, eleven_matrix, atol=BASE_MODEL_FREE_ELEVENS_ATOL)
     else:
         assert np.allclose(relu_l, eleven_matrix)
+    lowrank_factored = result.factored_solution[0] @ result.factored_solution[1]
+    np.testing.assert_allclose(lowrank_factored, result.reconstruction)

--- a/test/test_decompose_loop.py
+++ b/test/test_decompose_loop.py
@@ -21,6 +21,8 @@ from fi_nomad.types import (
     SVDStrategy,
 )
 
+from fi_nomad.util import two_part_factor
+
 TEST_KERNEL_TOLERANCE_ITERATIONS: int = 5
 PKG = "fi_nomad.entry"
 
@@ -41,7 +43,10 @@ class TestKernel(KernelBase):
 
     def report(self) -> KernelReturnType:
         return KernelReturnType(
-            "Complete", BaseModelFreeKernelReturnType(self.sparse_matrix_X)
+            "Complete",
+            BaseModelFreeKernelReturnType(
+                self.sparse_matrix_X, two_part_factor(self.sparse_matrix_X)
+            ),
         )
 
 
@@ -220,6 +225,9 @@ def test_decompose_obeys_max_iterations(mock_get_kernel: Mock) -> None:
     assert mock_kernel.elapsed_iterations == max_iterations
     np.testing.assert_array_equal(
         sparse_matrix, cast(FloatArrayType, result.reconstruction)
+    )
+    np.testing.assert_allclose(
+        sparse_matrix, result.factored_solution[0] @ result.factored_solution[1]
     )
 
 

--- a/test/test_decompose_loop.py
+++ b/test/test_decompose_loop.py
@@ -44,9 +44,7 @@ class TestKernel(KernelBase):
     def report(self) -> KernelReturnType:
         return KernelReturnType(
             "Complete",
-            BaseModelFreeKernelReturnType(
-                self.sparse_matrix_X, two_part_factor(self.sparse_matrix_X)
-            ),
+            BaseModelFreeKernelReturnType(two_part_factor(self.sparse_matrix_X)),
         )
 
 
@@ -223,12 +221,7 @@ def test_decompose_obeys_max_iterations(mock_get_kernel: Mock) -> None:
     assert passed_input.tolerance is None
 
     assert mock_kernel.elapsed_iterations == max_iterations
-    np.testing.assert_array_equal(
-        sparse_matrix, cast(FloatArrayType, result.reconstruction)
-    )
-    np.testing.assert_allclose(
-        sparse_matrix, result.factored_solution[0] @ result.factored_solution[1]
-    )
+    np.testing.assert_allclose(sparse_matrix, result.factors[0] @ result.factors[1])
 
 
 @patch(f"{PKG}.instantiate_kernel")

--- a/test/test_kernels/test_base_model_free_kernel.py
+++ b/test/test_kernels/test_base_model_free_kernel.py
@@ -99,14 +99,11 @@ def test_base_model_free_kernel_final_report(fixture_no_tol: Fixture) -> None:
 
     result_1 = kernel.report()
     assert "Not Tracked" in result_1.summary
-    np.testing.assert_array_equal(
-        indata.low_rank_candidate_L, cast(FloatArrayType, result_1.data.reconstruction)
-    )
     np.testing.assert_allclose(
         indata.low_rank_candidate_L,
         cast(
             FloatArrayType,
-            result_1.data.factored_solution[0] @ result_1.data.factored_solution[1],
+            result_1.data.factors[0] @ result_1.data.factors[1],
         ),
     )
 

--- a/test/test_kernels/test_base_model_free_kernel.py
+++ b/test/test_kernels/test_base_model_free_kernel.py
@@ -102,6 +102,13 @@ def test_base_model_free_kernel_final_report(fixture_no_tol: Fixture) -> None:
     np.testing.assert_array_equal(
         indata.low_rank_candidate_L, cast(FloatArrayType, result_1.data.reconstruction)
     )
+    np.testing.assert_allclose(
+        indata.low_rank_candidate_L,
+        cast(
+            FloatArrayType,
+            result_1.data.factored_solution[0] @ result_1.data.factored_solution[1],
+        ),
+    )
 
     kernel.loss = 3.0
     result_2 = kernel.report()

--- a/test/test_kernels/test_rowwise_variance_gaussian_model_kernel.py
+++ b/test/test_kernels/test_rowwise_variance_gaussian_model_kernel.py
@@ -58,12 +58,9 @@ def test_rowwise_variance_gauss_model_final_report(fixture: Fixture) -> None:
     assert "0 total iterations" in result.summary
     assert "final loss" in result.summary
     assert "likelihood" in result.summary
-    np.testing.assert_array_equal(
-        result.data.reconstruction, indata.low_rank_candidate_L
-    )
     np.testing.assert_allclose(
         indata.low_rank_candidate_L,
-        result.data.factored_solution[0] @ result.data.factored_solution[1],
+        result.data.factors[0] @ result.data.factors[1],
     )
     result_data = cast(RowwiseVarianceGaussianModelKernelReturnType, result.data)
     np.testing.assert_array_equal(

--- a/test/test_kernels/test_rowwise_variance_gaussian_model_kernel.py
+++ b/test/test_kernels/test_rowwise_variance_gaussian_model_kernel.py
@@ -61,6 +61,10 @@ def test_rowwise_variance_gauss_model_final_report(fixture: Fixture) -> None:
     np.testing.assert_array_equal(
         result.data.reconstruction, indata.low_rank_candidate_L
     )
+    np.testing.assert_allclose(
+        indata.low_rank_candidate_L,
+        result.data.factored_solution[0] @ result.data.factored_solution[1],
+    )
     result_data = cast(RowwiseVarianceGaussianModelKernelReturnType, result.data)
     np.testing.assert_array_equal(
         result_data.variance, np.var(indata.sparse_matrix_X, axis=1)

--- a/test/test_kernels/test_single_variance_gauss_model_kernel.py
+++ b/test/test_kernels/test_single_variance_gauss_model_kernel.py
@@ -64,6 +64,10 @@ def test_single_variance_gauss_model_final_report(fixture: Fixture) -> None:
     np.testing.assert_array_equal(
         result_data.reconstruction, indata.low_rank_candidate_L
     )
+    np.testing.assert_allclose(
+        indata.low_rank_candidate_L,
+        result_data.factored_solution[0] @ result_data.factored_solution[1],
+    )
     assert result_data.variance == float(np.var(indata.sparse_matrix_X))
 
 

--- a/test/test_kernels/test_single_variance_gauss_model_kernel.py
+++ b/test/test_kernels/test_single_variance_gauss_model_kernel.py
@@ -61,12 +61,9 @@ def test_single_variance_gauss_model_final_report(fixture: Fixture) -> None:
     assert "final loss" in result.summary
     assert "likelihood" in result.summary
     result_data = cast(SingleVarianceGaussianModelKernelReturnType, result.data)
-    np.testing.assert_array_equal(
-        result_data.reconstruction, indata.low_rank_candidate_L
-    )
     np.testing.assert_allclose(
         indata.low_rank_candidate_L,
-        result_data.factored_solution[0] @ result_data.factored_solution[1],
+        result_data.factors[0] @ result_data.factors[1],
     )
     assert result_data.variance == float(np.var(indata.sparse_matrix_X))
 

--- a/test/test_util/test_decomposition_util.py
+++ b/test/test_util/test_decomposition_util.py
@@ -12,6 +12,7 @@ from fi_nomad.util.decomposition_util import (
     _find_low_rank_random_truncated,
     _find_low_rank_exact_truncated,
     find_low_rank,
+    two_part_factor,
 )
 
 PKG = "fi_nomad.util.decomposition_util"
@@ -64,7 +65,7 @@ def test_svd_fns_recover_known_result(svdfn: SVDFnType) -> None:
     ])
     # fmt: on
     result = svdfn(low_rank_input, 1)
-    np.testing.assert_array_almost_equal(low_rank_input, result)
+    np.testing.assert_allclose(low_rank_input, result)
 
 
 # Note: "Exact Truncated" method omitted for this
@@ -82,7 +83,7 @@ def test_svd_fns_recover_full_rank_input_when_allowed_full_rank(
     ])
     # fmt: on
     returned_val = svdfn(base_matrix, max(base_matrix.shape))
-    np.testing.assert_array_almost_equal(base_matrix, returned_val)
+    np.testing.assert_allclose(base_matrix, returned_val)
 
 
 @patch(f"{PKG}._find_low_rank_random_truncated")
@@ -110,3 +111,18 @@ def test_find_low_rank_throws_on_unknown_strategy() -> None:
     util = np.ones((3, 2))
     with raises(ValueError, match="Unsupported"):
         _ = find_low_rank(util, 2, util, cast(SVDStrategy, -5))
+
+
+def test_two_part_factor() -> None:
+    # fmt: off
+    rank_two = np.array([
+        [ 1.,  0.1,  2.,  -0.3],
+        [ 5., -1.,  10.,   3. ],
+        [ 7.,  1.,  14.,  -3. ],
+        [ 9.,  2.,  18.,  -6. ]
+    ])
+    # fmt: on
+    (A, B) = two_part_factor(rank_two)
+    np.testing.assert_allclose(rank_two, A @ B)
+    assert A.shape == (4, 2)
+    assert B.shape == (2, 4)

--- a/test/test_util/test_gauss_model_util.py
+++ b/test/test_util/test_gauss_model_util.py
@@ -125,7 +125,7 @@ def test_estimate_new_model_rowwise_variance() -> None:
     result = estimate_new_model_variance(
         posterior_means, prior_means, var, rowwise=True
     )
-    np.testing.assert_array_almost_equal(expected, result)
+    np.testing.assert_allclose(expected, result)
 
 
 def test_get_stddev_normalized_matrix_gamma_scalar_variance() -> None:


### PR DESCRIPTION
Fixes #1.

This PR introduces the following changes:

- Update typing for kernel return types so that the expected return takes the format of a tuple of matrices ("`A`" and "`B`" for convenience) with the expectation that `A @ B`, their product, is the low-rank approximation returned by the kernel. (In the previous version of the code, this low-rank approximation was returned directly.)
- Adds a new function, `two_part_factor`, in the [decomposition utilities](src/fi_nomad/util/decomposition_util.py) which takes an input matrix `X` of dimension `(M x N)` and rank `r` and returns a `Tuple` of two matrices ("`A`" and "`B`" for convenience) such that `A @ B = X`, `A.shape = (M, r)`, and `B.shape = (r, N)`.
- Adds test for new utility function
- Updates unit and integration tests for existing kernels to confirm effective use of new function
- Updates documentation to describe the new return values and give example in readme