### PR TITLE
Per-iteration reporting: callback -> proper initialization.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ ignore = "__init__.py"
 disable = """
     too-many-arguments,
     too-many-locals,
+    too-many-instance-attributes,
     logging-fstring-interpolation,
     logging-not-lazy
 """

--- a/src/fi_nomad/entry.py
+++ b/src/fi_nomad/entry.py
@@ -22,7 +22,7 @@ from fi_nomad.types import (
 )
 from fi_nomad.kernels import KernelBase
 from fi_nomad.util import initialize_candidate
-from fi_nomad.util.factory_util import instantiate_kernel, get_diagnostic_fn
+from fi_nomad.util.factory_util import instantiate_kernel
 
 logger = logging.getLogger(__name__)
 
@@ -152,8 +152,12 @@ def decompose(
     )
 
     run_start_time = time.perf_counter()
-    kernel = instantiate_kernel(kernel_strategy, kernel_input, kernel_params)
-    output_diagnostic_data = get_diagnostic_fn(kernel, diagnostic_config)
+    kernel = instantiate_kernel(
+        kernel_strategy,
+        kernel_input,
+        kernel_params=kernel_params,
+        diagnostic_config=diagnostic_config,
+    )
 
     loop_start_time = time.perf_counter()
     while kernel.elapsed_iterations < max_iterations:
@@ -163,7 +167,7 @@ def decompose(
         running_report = kernel.running_report()
         if running_report != "":
             logger.info(running_report)
-        output_diagnostic_data()
+        kernel.per_iteration_diagnostic()
         if tolerance is not None and kernel.loss < tolerance:
             break
 

--- a/src/fi_nomad/util/factory_util.py
+++ b/src/fi_nomad/util/factory_util.py
@@ -2,10 +2,10 @@
 
 Functions:
     instantiate_kernel: Factory function for low-rank-estimator kernels.
-    get_diagnostic_fn: Given a kernel and diagnostic config, generate a per-iteration callback.
+    do_diagnostic_configuration: Configure kernel for per-iteration diagnostic output.
 
 """
-from typing import Callable, Optional, cast
+from typing import Optional, cast
 
 from fi_nomad.kernels import (
     KernelBase,
@@ -13,6 +13,7 @@ from fi_nomad.kernels import (
     RowwiseVarianceGaussianModelKernel,
     SingleVarianceGaussianModelKernel,
 )
+from fi_nomad.types.enums import DiagnosticLevel
 
 from fi_nomad.util.path_util import make_path
 
@@ -24,10 +25,18 @@ from fi_nomad.types import (
 )
 
 
+def empty_fn() -> None:  # pragma: no cover
+    """No-op function, used to replace per-iteration diagnostic data output
+    when caller requests no diagnostic output.
+    """
+
+
 def instantiate_kernel(
     s: KernelStrategy,
     data_in: KernelInputType,
+    *,
     kernel_params: Optional[KernelSpecificParameters] = None,
+    diagnostic_config: Optional[DiagnosticDataConfig] = None,
 ) -> KernelBase:
     """Factory function to instantiate and configure a decomposition kernel.
 
@@ -35,6 +44,8 @@ def instantiate_kernel(
         s: The defined KernelStrategy to instantiate
         data_in: Input data for the kernel
         kernel_params: Optional kernel-specific parameters. Defaults to None.
+        diagnostic_config: Optional configuration for per-iteration diagnostic
+            data output. Defaults to None (turning the feature off).
 
     Raises:
         NotImplementedError: Raised if optional kernel parameters are passed.
@@ -47,42 +58,44 @@ def instantiate_kernel(
         raise NotImplementedError(
             "No kernel is using these yet. Remove this note when implemented."
         )
+    kernel: Optional[KernelBase] = None
     if s == KernelStrategy.BASE_MODEL_FREE:
-        return BaseModelFree(data_in)
-    if s == KernelStrategy.GAUSSIAN_MODEL_SINGLE_VARIANCE:
-        return SingleVarianceGaussianModelKernel(data_in)
-    if s == KernelStrategy.GAUSSIAN_MODEL_ROWWISE_VARIANCE:
-        return RowwiseVarianceGaussianModelKernel(data_in)
-    raise ValueError(f"Unsupported kernel strategy {s}")
+        kernel = BaseModelFree(data_in)
+    elif s == KernelStrategy.GAUSSIAN_MODEL_SINGLE_VARIANCE:
+        kernel = SingleVarianceGaussianModelKernel(data_in)
+    elif s == KernelStrategy.GAUSSIAN_MODEL_ROWWISE_VARIANCE:
+        kernel = RowwiseVarianceGaussianModelKernel(data_in)
+    else:
+        raise ValueError(f"Unsupported kernel strategy {s}")
+    if kernel is None:
+        raise ValueError("Error in kernel configuration: kernel not initialized.")
+    kernel = do_diagnostic_configuration(kernel, diagnostic_config)
+    return kernel
 
 
-def get_diagnostic_fn(
+def do_diagnostic_configuration(
     kernel: KernelBase, config: Optional[DiagnosticDataConfig]
-) -> Callable[[], None]:
-    """Get appropriate callback for this kernel's per-iteration diagnostic output.
+) -> KernelBase:
+    """Configure kernel for per-iteration diagnostic output.
 
-    Note that if the "config" object is None/omitted, the returned value will be
-    a no-op. Also, because we are returning a callback that is instantiated before
-    the main loop begins, implementing kernels should not expect to be able to
-    change configuration values during loop execution.
+    Note that if the "config" object is None/omitted, or if the requested level
+    is NONE, the kernel's diagnostic function will be replaced with a no-op.
 
     Args:
         kernel: Instantiated kernel capable of reporting
         config: Configuration object for diagnostic data setup. Defaults to None.
 
     Returns:
-        A parameterless callback which the main decompose loop can execute at
-        every pass, to allow the kernel to do whatever kernel-specific detailed
-        diagnostic logging is desired (e.g. writing data files, internal state).
+        The kernel, with stored config, and per-iteration method replaced if
+        turned off by the caller.
     """
-    if config is None:
-        return lambda: None
+    if config is None or config.diagnostic_level == DiagnosticLevel.NONE:
+        # rather than execute a test on every iteration, replace with no-op
+        kernel.per_iteration_diagnostic = empty_fn  # type: ignore[method-assign]
+        return kernel
     config = cast(DiagnosticDataConfig, config)
-
-    req_level = config.diagnostic_level
+    kernel.diagnostic_level = config.diagnostic_level
     req_basedir = config.diagnostic_output_basedir
     req_exact = config.use_exact_diagnostic_basepath
-    diag_outdir = make_path(req_basedir, use_exact_path=req_exact)
-    return lambda: kernel.per_iteration_diagnostic(
-        diagnostic_level=req_level, out_dir=diag_outdir
-    )
+    kernel.out_dir = make_path(req_basedir, use_exact_path=req_exact)
+    return kernel

--- a/test/test_kernels/test_base_model_free_kernel.py
+++ b/test/test_kernels/test_base_model_free_kernel.py
@@ -119,14 +119,14 @@ def test_base_model_free_kernel_final_report(fixture_no_tol: Fixture) -> None:
     assert "3.0" in result_2.summary
 
 
-def test_base_model_free_kernel_per_iteration_diagnostic_does_nothing(
+def test_base_model_free_kernel_per_iteration_diagnostic_calls_base(
     fixture_no_tol: Fixture, caplog: LogCaptureFixture
 ) -> None:
     (_, kernel) = fixture_no_tol
     test_path_str = "test-path"
     test_path = Path(test_path_str)
-    kernel.per_iteration_diagnostic(
-        diagnostic_level=DiagnosticLevel.MINIMAL, out_dir=test_path
-    )
+    kernel.out_dir = test_path
+    kernel.diagnostic_level = DiagnosticLevel.MINIMAL
+    kernel.per_iteration_diagnostic()
     assert "Per-iteration diagnostic" in caplog.text
     assert f"{test_path_str}" in caplog.text

--- a/test/test_util/test_factory_util.py
+++ b/test/test_util/test_factory_util.py
@@ -7,7 +7,11 @@ from fi_nomad.types.types import DiagnosticDataConfig
 from fi_nomad.kernels.kernel_base import KernelBase
 
 
-from fi_nomad.util.factory_util import instantiate_kernel, get_diagnostic_fn
+from fi_nomad.util.factory_util import (
+    instantiate_kernel,
+    do_diagnostic_configuration,
+    empty_fn,
+)
 
 PKG = "fi_nomad.util.factory_util"
 
@@ -18,12 +22,22 @@ def test_instantiate_kernel_throws_on_unsupported_kernel() -> None:
         _ = instantiate_kernel(KernelStrategy.TEST, mock_data_in)
 
 
+@patch(f"{PKG}.BaseModelFree", autospec=True)
+def test_insantiate_kernel_throws_on_instantiation_failure(mock_base: Mock) -> None:
+    mock_data_in = Mock()
+    mock_base.return_value = None
+    with raises(ValueError, match="not initialized"):
+        _ = instantiate_kernel(KernelStrategy.BASE_MODEL_FREE, mock_data_in)
+
+
 def test_instantiate_kernel_throws_on_unsupported_feature() -> None:
     mock_data_in = Mock()
     some_non_null_value = 0.5
     with raises(NotImplementedError):
         _ = instantiate_kernel(
-            KernelStrategy.BASE_MODEL_FREE, mock_data_in, some_non_null_value
+            KernelStrategy.BASE_MODEL_FREE,
+            mock_data_in,
+            kernel_params=some_non_null_value,
         )
 
 
@@ -34,7 +48,9 @@ def test_instantiate_kernel_honors_strategy_selection(
     mock_base: Mock, mock_svgauss: Mock, mock_rwgauss: Mock
 ) -> None:
     mock_data_in = Mock()
-    _ = instantiate_kernel(KernelStrategy.BASE_MODEL_FREE, mock_data_in)
+    base_response = instantiate_kernel(KernelStrategy.BASE_MODEL_FREE, mock_data_in)
+    # Confirms that we are actually calling do_diagnostic_configuration
+    assert base_response.per_iteration_diagnostic == empty_fn
     mock_base.assert_called_once()
     _ = instantiate_kernel(KernelStrategy.GAUSSIAN_MODEL_SINGLE_VARIANCE, mock_data_in)
     mock_svgauss.assert_called_once()
@@ -42,14 +58,21 @@ def test_instantiate_kernel_honors_strategy_selection(
     mock_rwgauss.assert_called_once()
 
 
-def test_get_diagnostic_fn_returns_null_fn_on_no_config() -> None:
+def test_do_diagnostic_configuration_clears_fn_on_no_config() -> None:
     mock_kernel = Mock()
-    res = get_diagnostic_fn(cast(KernelBase, mock_kernel), None)
-    assert res() == None
+    res = do_diagnostic_configuration(cast(KernelBase, mock_kernel), None)
+    assert res.per_iteration_diagnostic == empty_fn
+
+
+def test_do_diagnostic_configuration_clears_fn_on_none_level() -> None:
+    mock_kernel = Mock()
+    mock_diag_config = DiagnosticDataConfig(DiagnosticLevel.NONE, "unused", False)
+    res = do_diagnostic_configuration(cast(KernelBase, mock_kernel), mock_diag_config)
+    assert res.per_iteration_diagnostic == empty_fn
 
 
 @patch(f"{PKG}.make_path")
-def test_get_diagnostic_fn_returns_callback(mock_make_path: Mock) -> None:
+def test_get_diagnostic_fn_configures_kernel(mock_make_path: Mock) -> None:
     mock_kernel = Mock()
     mock_basedir = "MOCK_BASEDIR"
     mock_outpath = "MOCK_PATH"
@@ -58,15 +81,7 @@ def test_get_diagnostic_fn_returns_callback(mock_make_path: Mock) -> None:
     mock_diag_config = DiagnosticDataConfig(
         DiagnosticLevel.EXTREME, mock_basedir, False
     )
-
-    def mock_callback(
-        *, diagnostic_level: DiagnosticLevel, out_dir: str
-    ) -> Tuple[DiagnosticLevel, str]:
-        return (diagnostic_level, out_dir)
-
-    mock_kernel.per_iteration_diagnostic = mock_callback
-
-    callback = get_diagnostic_fn(cast(KernelBase, mock_kernel), mock_diag_config)
+    res = do_diagnostic_configuration(cast(KernelBase, mock_kernel), mock_diag_config)
     mock_make_path.assert_called_once_with(mock_basedir, use_exact_path=False)
-    res = callback()
-    assert res == (DiagnosticLevel.EXTREME, mock_outpath)
+    assert res.diagnostic_level == mock_diag_config.diagnostic_level
+    assert str(res.out_dir) == mock_outpath


### PR DESCRIPTION
See #7.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an unintended
or erroneous behavior)
- [ ] New features (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes how existing
functionality works, other than correcting errors)
- [x] Code improvement (no new functionality, but improving project structure)
- [ ] Documentation only (changes that improve or expand instructions
to users, without changing program behavior)


## Motivation and Context
After further reflection on PR #11, I felt the "get a callback and call that" thing was a little hacky. This functionality is continuing to evolve and we may re-open Issue #7 if the design changes much more--the big open question at this point is whether to give more control over frequency of output to the main loop, or leave this the responsibility of implementing kernels.

## Description

This PR introduces the following changes:

* In `factory_util.py`, change diagnostic-callback function to `do_diagnostic_configuration`
  * Move diagnostic-output configuration into instantiation (as a call from the main factory function) rather than a separate call by main loop
* Corresponding changes to `decompose`
* Corresponding changes to base-class implementation (look at `self` rather than parameters)
* Corresponding changes to tests
* Update docstrings and readme

## Testing

* Adjusted automated tests to use the new calling convention
  * `test_decompose_loop.py`: assign a spy to the mocked kernel and check its call count, instead of creating a mock callback
  * `test_base_model_free_kernel.py`: Clarify name of test of the base-class per-iteration-diagnostic; update mocks to make sure it gets called.
  * `test_factory_util.py`:
    * In strategy-selection check, make sure the diagnostic config is actually called
    * Check against known no-op function for case where no config is passed or requested diagnostic-output level is `NONE`
* As part of code changes, added a step to factory function. This necessitated a new check to catch the case where a kernel constructor returned `None` through error

## Checklist
- [x] My code follows the project code style
  - [x] I've run the automatic formatters and made any needed changes
  - [x] I've ensured that my new code is explained in docstrings/comments
- [ ] My submission requires a change to the documentation
  - [ ] I've updated the documentation to reflect the changes
- [X] I've added unit tests that cover the visible behavior of the changes
- [ ] I've added or modified integration tests that ensure the whole system
works on a practical problem after my changes