### PR TITLE
Increment elapsed iterations after kernel step (not before)

### DIFF
--- a/src/fi_nomad/entry.py
+++ b/src/fi_nomad/entry.py
@@ -161,8 +161,8 @@ def decompose(
 
     loop_start_time = time.perf_counter()
     while kernel.elapsed_iterations < max_iterations:
-        kernel.increment_elapsed()
         kernel.step()
+        kernel.increment_elapsed()
 
         running_report = kernel.running_report()
         if running_report != "":

--- a/src/fi_nomad/kernels/base_model_free.py
+++ b/src/fi_nomad/kernels/base_model_free.py
@@ -4,6 +4,7 @@ Classes:
     BaseModelFree: A "naive" no-model kernel.
 
 """
+
 from fi_nomad.kernels.kernel_base import KernelBase
 from fi_nomad.util.base_model_free_util import construct_utility
 

--- a/src/fi_nomad/kernels/kernel_base.py
+++ b/src/fi_nomad/kernels/kernel_base.py
@@ -5,6 +5,7 @@ Classes:
     KernelBase: Abstract base class for kernel classes.
 
 """
+
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 from pathlib import Path

--- a/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
@@ -4,6 +4,7 @@ Classes:
     RowwiseVarianceGaussianModelKernel: Gaussian-model kernel with per-row variance.
 
 """
+
 from typing import Tuple, cast
 import logging
 import numpy as np

--- a/src/fi_nomad/kernels/single_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/single_variance_gauss_model.py
@@ -4,6 +4,7 @@ Classes:
     SingleVarianceGaussianModelKernel: Gaussian-model kernel with scalar variance.
 
 """
+
 from typing import cast
 import logging
 import numpy as np

--- a/src/fi_nomad/types/enums.py
+++ b/src/fi_nomad/types/enums.py
@@ -7,6 +7,7 @@ Classes:
     KernelStrategy: Choices of decomposition kernel.
 
 """
+
 from enum import Enum
 
 

--- a/src/fi_nomad/types/kernelInputTypes.py
+++ b/src/fi_nomad/types/kernelInputTypes.py
@@ -5,6 +5,7 @@ Classes:
     KernelInputType: Standard data object for initializing kernels.
 
 """
+
 from typing import NamedTuple, Union
 from .types import FloatArrayType
 from .enums import SVDStrategy

--- a/src/fi_nomad/types/kernelReturnTypes.py
+++ b/src/fi_nomad/types/kernelReturnTypes.py
@@ -8,6 +8,7 @@ Classes:
     KernelReturnType: Combination of data and summary string.
 
 """
+
 from abc import ABC
 from typing import Tuple, Union
 from dataclasses import dataclass

--- a/src/fi_nomad/types/types.py
+++ b/src/fi_nomad/types/types.py
@@ -4,6 +4,7 @@ Classes:
     DecomposeInput: Nominal structured input for decompose loop. Not used.
 
 """
+
 from typing import NamedTuple, Optional
 import numpy as np
 import numpy.typing as npt

--- a/src/fi_nomad/util/base_model_free_util.py
+++ b/src/fi_nomad/util/base_model_free_util.py
@@ -5,6 +5,7 @@ Functions:
     construct_utility: Construct candidate by enforcing base matrix constraints on an SVD result.
 
 """
+
 import numpy as np
 from fi_nomad.types import FloatArrayType
 

--- a/src/fi_nomad/util/decomposition_util.py
+++ b/src/fi_nomad/util/decomposition_util.py
@@ -5,6 +5,7 @@ Functions:
     two_part_factor: Factor M x N matrix of rank r into A (M x r), B (r x N)
 
 """
+
 from typing import Tuple
 import numpy as np
 from sklearn.decomposition import TruncatedSVD  # type: ignore

--- a/src/fi_nomad/util/factory_util.py
+++ b/src/fi_nomad/util/factory_util.py
@@ -5,6 +5,7 @@ Functions:
     do_diagnostic_configuration: Configure kernel for per-iteration diagnostic output.
 
 """
+
 from typing import Optional, cast
 
 from fi_nomad.kernels import (

--- a/src/fi_nomad/util/gauss_model_util.py
+++ b/src/fi_nomad/util/gauss_model_util.py
@@ -12,6 +12,7 @@ Functions:
     target_matrix_log_likelihood: Finds log likelihood of target matrix with current parameters.
 
 """
+
 from typing import Union, cast, Any
 import numpy as np
 from scipy.stats import norm as normal  # type: ignore

--- a/src/fi_nomad/util/initialization_util.py
+++ b/src/fi_nomad/util/initialization_util.py
@@ -5,6 +5,7 @@ Functions:
     initialize_candidate: Wrapper for initializing low-rank candidate with error handling.
 
 """
+
 from typing import Optional
 import numpy as np
 

--- a/src/fi_nomad/util/loss_util.py
+++ b/src/fi_nomad/util/loss_util.py
@@ -4,6 +4,7 @@ Functions:
     compute_loss: Computes scalar loss estimate between utility and target matrices.
 
 """
+
 import numpy as np
 
 from fi_nomad.types import FloatArrayType, LossType

--- a/src/fi_nomad/util/path_util.py
+++ b/src/fi_nomad/util/path_util.py
@@ -4,6 +4,7 @@ Functions:
     make_path: Makes an output path from a user-specified base.
 
 """
+
 from pathlib import Path
 from datetime import datetime
 from os import path, makedirs

--- a/src/fi_nomad/util/stats_util.py
+++ b/src/fi_nomad/util/stats_util.py
@@ -4,6 +4,7 @@ Functions:
     pdf_to_cdf_ratio_psi: Computes PDF/CDF for a (0, 1) Gaussian.
 
 """
+
 from typing import cast, Union
 import numpy as np
 from scipy.stats import norm as normal  # type: ignore

--- a/test/test_decompose_loop.py
+++ b/test/test_decompose_loop.py
@@ -31,7 +31,8 @@ class TestKernel(KernelBase):
         super().__init__(input)
 
     def step(self) -> None:
-        if self.elapsed_iterations >= TEST_KERNEL_TOLERANCE_ITERATIONS:
+        # elapsed_iterations + 1 gives the iteration we're currently in
+        if self.elapsed_iterations + 1 >= TEST_KERNEL_TOLERANCE_ITERATIONS:
             if self.tolerance is not None:
                 self.loss = self.tolerance - 1
 


### PR DESCRIPTION
Increment `elapsed_iterations` counter after a kernel step has been performed.

Closes #14 .

### Type of change
- [x] Bug fix (non-breaking change which fixes an unintended
or erroneous behavior)
- [ ] New features (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes how existing
functionality works, other than correcting errors)
- [ ] Code improvement (no new functionality, but improving project structure)
- [ ] Documentation only (changes that improve or expand instructions
to users, without changing program behavior)


## Motivation and Context
A kernel step might perform actions conditionally on elapsed iterations, therefore the number must be accurate. Currently, while performing a kernel step, its attribute `elapsed_iterations` tracks the number of iterations that had happened before, plus the one it is performing at the moment.

## Description
This PR introduces the following changes:

* Switched order of `kernel.step()`and `kernel.increment_elapsed()` such that the kernel step is performed first and the elapsed iterations updated afterwards.
* Added an explicit unit test `test_kernel_step_called_before_increment_elapsed` to `test_decompose_loop.py`
* Adjusted class `TestKernel` in `test_decompose_loop.py`
* Applying code formatting using Black, affecting several files with the addition of blank lines in the description headers.

## How to Review
The commit d8eb75594749fdc87cde6e826e5b3cfd7889ed1e is focused solely on formatting adjustments made by Black and does not directly address the issue.

## Testing
* Explicit unit test `test_kernel_step_called_before_increment_elapsed` in `test_decompose_loop.py`
  * Mocks the kernel and its step() and increment_elapsed() methods.
  * Executes a decompose loop with manual_max_iterations=1 using existing fixtures.
  * Verifies the call order to ensure step() precedes increment_elapsed()
* Adjustments were made to TestKernel in test_decompose_loop.py to align with the changes.

## Checklist
- [x] My code follows the project code style
  - [x] I've run the automatic formatters and made any needed changes
  - [x] I've ensured that my new code is explained in docstrings/comments
- [ ] My submission requires a change to the documentation
  - [ ] I've updated the documentation to reflect the changes
- [x] I've added unit tests that cover the visible behavior of the changes
- [ ] I've added or modified integration tests that ensure the whole system
works on a practical problem after my changes
