### PR TITLE
Merge `two_part_factor` and `two_part_factor_known_rank`

### DIFF
--- a/src/fi_nomad/kernels/base_model_free.py
+++ b/src/fi_nomad/kernels/base_model_free.py
@@ -79,7 +79,9 @@ class BaseModelFree(KernelBase):
         """
         floss = str(self.loss) if self.loss != float("inf") else "Not Tracked"
         text = f"{self.elapsed_iterations} total, final loss {floss}"
-        data = BaseModelFreeKernelReturnType(two_part_factor(self.low_rank_candidate_L))
+        data = BaseModelFreeKernelReturnType(
+            two_part_factor(self.low_rank_candidate_L, self.target_rank)
+        )
         return KernelReturnType(text, data)
 
 

--- a/src/fi_nomad/kernels/momentum_three_block_model_free.py
+++ b/src/fi_nomad/kernels/momentum_three_block_model_free.py
@@ -20,7 +20,7 @@ from fi_nomad.types import (
     LossType,
 )
 
-from fi_nomad.util import compute_loss, two_part_factor_known_rank
+from fi_nomad.util import compute_loss, two_part_factor
 
 
 class Momentum3BlockModelFreeKernel(KernelBase):
@@ -54,7 +54,7 @@ class Momentum3BlockModelFreeKernel(KernelBase):
             self.candidate_factor_H = custom_params.candidate_factor_H0
         else:
             # if W0, H0 are not given, factorize low_rank_candidate_L
-            (candidate_factor_W0, candidate_factor_H0) = two_part_factor_known_rank(
+            (candidate_factor_W0, candidate_factor_H0) = two_part_factor(
                 self.low_rank_candidate_L,
                 self.target_rank,
             )

--- a/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/rowwise_variance_gauss_model.py
@@ -200,7 +200,7 @@ class RowwiseVarianceGaussianModelKernel(KernelBase):
             + f"likelihood {self.likelihood}"
         )
         data = RowwiseVarianceGaussianModelKernelReturnType(
-            two_part_factor(self.model_means_L),
+            two_part_factor(self.model_means_L, self.target_rank),
             self.model_variance_sigma_squared,
         )
         return KernelReturnType(text, data)

--- a/src/fi_nomad/kernels/single_variance_gauss_model.py
+++ b/src/fi_nomad/kernels/single_variance_gauss_model.py
@@ -126,7 +126,7 @@ class SingleVarianceGaussianModelKernel(KernelBase):
             + f"{self.loss} likelihood {self.likelihood}"
         )
         data = SingleVarianceGaussianModelKernelReturnType(
-            two_part_factor(self.model_means_L),
+            two_part_factor(self.model_means_L, self.target_rank),
             self.model_variance_sigma_squared,
         )
         return KernelReturnType(text, data)

--- a/src/fi_nomad/util/__init__.py
+++ b/src/fi_nomad/util/__init__.py
@@ -1,7 +1,6 @@
 from .decomposition_util import (
     find_low_rank as find_low_rank,
     two_part_factor as two_part_factor,
-    two_part_factor_known_rank as two_part_factor_known_rank,
 )
 from .initialization_util import (
     initialize_low_rank_candidate as initialize_low_rank_candidate,

--- a/src/fi_nomad/util/decomposition_util.py
+++ b/src/fi_nomad/util/decomposition_util.py
@@ -2,12 +2,11 @@
 
 Functions:
     find_low_rank: Compute low-rank approximation to input matrix using stated SVD strategy.
-    two_part_factor: Factor M x N matrix of rank r into A (M x r), B (r x N)
-    two_part_factor_known_rank: Factor M x N matrix into A (M x r), B (r x N) with known rank r.
-
+    two_part_factor: Factor M x N matrix of rank r into A (M x r), B (r x N) with 
+        optional known rank.
 """
 
-from typing import Tuple
+from typing import Tuple, Optional
 import numpy as np
 from sklearn.decomposition import TruncatedSVD  # type: ignore
 
@@ -124,36 +123,21 @@ def find_low_rank(
     raise ValueError("Unsupported SVD strategy.")
 
 
-def two_part_factor(matrix: FloatArrayType) -> Tuple[FloatArrayType, FloatArrayType]:
+def two_part_factor(
+    matrix: FloatArrayType, rank: Optional[int] = None
+) -> Tuple[FloatArrayType, FloatArrayType]:
     """Factor matrix into two rectangular matrices with inner dimension matching its rank.
 
     Args:
         matrix: Low-rank matrix to factor into two
+        rank: The desired inner dimension. Defaults to `None`, in this case
+            detects the rank using `np.linalg.matrix_rank(matrix)`
 
     Returns:
         Two matrices whose product is the original matrix.
     """
-    rank = np.linalg.matrix_rank(matrix)
-    (svd_U, svd_S, svd_Vt) = np.linalg.svd(matrix)
-    inner_a = np.zeros((matrix.shape[0], rank))
-    np.fill_diagonal(inner_a, svd_S)
-    part_A = svd_U @ inner_a
-    part_B = np.pad(np.eye(rank), ((0, 0), (0, matrix.shape[1] - rank))) @ svd_Vt
-    return (part_A, part_B)
-
-
-def two_part_factor_known_rank(
-    matrix: FloatArrayType, rank: int
-) -> Tuple[FloatArrayType, FloatArrayType]:
-    """Factor matrix into two rectangular matrices with inner dimension `rank`
-
-    Args:
-        matrix: Low-rank matrix to factor into two
-        rank: The desired inner dimension
-
-    Returns:
-        Two matrices whose product is the original matrix.
-    """
+    if rank is None:
+        rank = np.linalg.matrix_rank(matrix)
     (svd_U, svd_S, svd_Vt) = np.linalg.svd(matrix)
     inner_a = np.zeros((matrix.shape[0], rank))
     np.fill_diagonal(inner_a, svd_S)

--- a/test/test_kernels/test_base_model_free_kernel.py
+++ b/test/test_kernels/test_base_model_free_kernel.py
@@ -104,6 +104,10 @@ def test_base_model_free_kernel_running_report(fixture_no_tol: Fixture) -> None:
 def test_base_model_free_kernel_final_report(fixture_no_tol: Fixture) -> None:
     (indata, kernel) = fixture_no_tol
 
+    # rank of the low rank candidate before a step was performed is 1,
+    # due to initialization as `np.ones(...)`
+    kernel.target_rank = 1
+
     result_1 = kernel.report()
     assert "Not Tracked" in result_1.summary
     np.testing.assert_allclose(

--- a/test/test_util/test_decomposition_util.py
+++ b/test/test_util/test_decomposition_util.py
@@ -113,7 +113,8 @@ def test_find_low_rank_throws_on_unknown_strategy() -> None:
         _ = find_low_rank(util, 2, util, cast(SVDStrategy, -5))
 
 
-def test_two_part_factor() -> None:
+def test_two_part_factor_rank_unknown() -> None:
+
     # fmt: off
     rank_two = np.array([
         [ 1.,  0.1,  2.,  -0.3],
@@ -123,6 +124,24 @@ def test_two_part_factor() -> None:
     ])
     # fmt: on
     (A, B) = two_part_factor(rank_two)
+    np.testing.assert_allclose(rank_two, A @ B)
+    assert A.shape == (4, 2)
+    assert B.shape == (2, 4)
+
+
+@patch("numpy.linalg.matrix_rank")
+def test_two_part_factor_rank_known(mock_matrix_rank: Mock) -> None:
+    # fmt: off
+    rank_two = np.array([
+        [ 1.,  0.1,  2.,  -0.3],
+        [ 5., -1.,  10.,   3. ],
+        [ 7.,  1.,  14.,  -3. ],
+        [ 9.,  2.,  18.,  -6. ]
+    ])
+    # fmt: on
+    rank = 2
+    (A, B) = two_part_factor(rank_two, rank)
+    mock_matrix_rank.assert_not_called()
     np.testing.assert_allclose(rank_two, A @ B)
     assert A.shape == (4, 2)
     assert B.shape == (2, 4)

--- a/test/test_util/test_decomposition_util.py
+++ b/test/test_util/test_decomposition_util.py
@@ -114,7 +114,6 @@ def test_find_low_rank_throws_on_unknown_strategy() -> None:
 
 
 def test_two_part_factor_rank_unknown() -> None:
-
     # fmt: off
     rank_two = np.array([
         [ 1.,  0.1,  2.,  -0.3],


### PR DESCRIPTION
<!-- Provide a one-sentence summary here. -->
As discussed in PR #16, we know the low-rank candidate's rank, therefore merging `two_part_factor` with `two_part_factor_known_rank` to reduce repeated code.

<!-- If your PR resolves an open issue, put the issue number here. -->
Closes #17 .

### Type of change
<!-- Choose one by putting an X in the box [ ] -->
- [ ] Bug fix (non-breaking change which fixes an unintended
or erroneous behavior)
- [ ] New features (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes how existing
functionality works, other than correcting errors)
- [x] Code improvement (no new functionality, but improving project structure)
- [ ] Documentation only (changes that improve or expand instructions
to users, without changing program behavior)


## Motivation and Context
The change avoids code repetition and matrix rank computation. It merges functions `two_part_factor` and `two_part_factor_known_rank` into a single function `two_part_factor` with optional argument `rank`. If rank is not supplied, it will be detected using `numpy.linalg.matrix_rank`. For the current use cases, we always now the target rank in advance. Currently, the function is used twofold: 
- Instantiating  `candidate_factor_W0` and `candidate_factor_H0` in kernel `Momentum3BlockModelFreeKernel` if argument `low_rank_candidate_L` was supplied but either (or both) `W0` and `H0` were omitted
- Factorizing the result `low_rank_candidate_L` into `W` and `H` for algorithms that return only `L` (currently: base model-free, gaussian model with single variance parameter and gaussian model with rowwise variance parameter). This is done in kernel methods `self.report()`


## Description
This PR introduces the following changes:

* Alter `two_part_factor` to accept optional parameter `rank`
  * `two_part_factor` now has an optional integer parameter `rank`
  * If rank is `None` (the default) it is computed using `numpy.linalg.matrix_rank`
  * Adapted docstring
  * Removed `two_part_factor_known_rank`
  * Files changed: `src/fi_nomad/util/decomposition_util.py`, `src/fi_nomad/util/__init__.py`
* Updated kernels accordingly
  * Added kernel fields `kernel.target_rank` as second argument to `two_part_factor`
  * Files changed: `src/fi_nomad/kernels/base_model_free.py`, `src/fi_nomad/kernels/single_variance_gauss_model.py`, `src/fi_nomad/kernels/rowwise_variance_gauss_model.py`, `src/fi_nomad/kernels/momentum_three_block_model_free.py`


## Testing
- I split up `test_two_part_factor` into:
  - `test_two_part_factor_rank_unknown`: where the target rank is determined by `numpy.linalg.matrix_rank`
  - `test_two_part_factor_rank_known`: where `rank` is supplied as an argument, and check that `numpy.linalg.matrix_rank` is not called
  - Files changed: `test/test_util/test_decomposition_util.py`
- I altered `test_base_model_free_kernel_final_report`:
  - setting `kernel.target_rank = 1` as no kernel step has been made and the low rank candidate L is initialized as `np.ones(...)`, thus having rank 1
  - Files changed: `test/test_kernels/test_base_model_free_kernel.py`


## Checklist
<!-- Check off all that you've done. -->
- [x] My code follows the project code style
  - [x] I've run the automatic formatters and made any needed changes
  - [x] I've ensured that my new code is explained in docstrings/comments
- [ ] My submission requires a change to the documentation
  - [ ] I've updated the documentation to reflect the changes
- [x] I've added unit tests that cover the visible behavior of the changes
- [ ] I've added or modified integration tests that ensure the whole system
works on a practical problem after my changes

