### PR TITLE
Update typing to support numpy 2.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=2.0.0",
+    "numpy>=1.24.0",
     "scipy>=1.10.0",
     "scikit-learn>=1.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.24.0",
+    "numpy>=2.0.0",
     "scipy>=1.10.0",
     "scikit-learn>=1.3.0"
 ]

--- a/src/fi_nomad/types/types.py
+++ b/src/fi_nomad/types/types.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 from .enums import KernelStrategy, SVDStrategy, InitializationStrategy, DiagnosticLevel
 
-FloatArrayType = npt.NDArray[np.float_]
+FloatArrayType = npt.NDArray[np.float64]
 
 
 class DiagnosticDataConfig(NamedTuple):


### PR DESCRIPTION
Allows support for Numpy 2.0, released in June 2024.

### Type of change
- [x] Bug fix (non-breaking change which fixes an unintended
or erroneous behavior)
- [ ] New features (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes how existing
functionality works, other than correcting errors)
- [ ] Code improvement (no new functionality, but improving project structure)
- [ ] Documentation only (changes that improve or expand instructions
to users, without changing program behavior)


## Motivation and Context
Numpy has released a new major version, the first in over a decade. Most of the changes won't affect this project, however they did deprecate use of the `numpy.float_` type. In order to support the new major Numpy version, we need to change references to `float_` to `float64`.

## Description
This is a one-line change affecting only the base type definition for our internal float array type alias.

## Testing

No new tests needed to be added; just had to be sure that the changes do not affect loading the library or existing tests.

## Checklist
<!-- Check off all that you've done. -->
- [x] My code follows the project code style
  - [x] I've run the automatic formatters and made any needed changes
  - [x] I've ensured that my new code is explained in docstrings/comments
- [ ] My submission requires a change to the documentation
  - [ ] I've updated the documentation to reflect the changes
- [ ] I've added unit tests that cover the visible behavior of the changes
- [ ] I've added or modified integration tests that ensure the whole system
works on a practical problem after my changes


## Closing thoughts

While we now support Numpy up to 2.0, we don't require it.